### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and offers both synchronous and asynchronous clients powered by [httpx](https://
 
 ## Documentation
 
-The API documentation can be found [here](https://developer.tryfinch.com/).
+The API documentation can be found [in the Finch Documentation Center](https://developer.tryfinch.com/).
 
 ## Installation
 
@@ -306,7 +306,10 @@ See the httpx documentation for information about the [`proxies`](https://www.py
 
 ### Managing HTTP resources
 
-By default we will close the underlying HTTP connections whenever the client is [garbage collected](https://docs.python.org/3/reference/datamodel.html#object.__del__) is called but you can also manually close the client using the `.close()` method if desired, or with a context manager that closes when exiting.
+By default, we will close the underlying HTTP connections whenever the client is 
+[garbage collected](https://docs.python.org/3/reference/datamodel.html#object.__del__), 
+but you can also manually close the client using the `.close()` method 
+if desired, or with a context manager that closes when exiting.
 
 ## Versioning
 

--- a/api.md
+++ b/api.md
@@ -97,7 +97,7 @@ Types:
 from finch.types.hris import (
     BenefitFrequency,
     BenefitType,
-    BenfitContribution,
+    BenefitContribution,
     CompanyBenefit,
     CreateCompanyBenefitsResponse,
     SupportedBenefit,

--- a/src/finch/types/hris/__init__.py
+++ b/src/finch/types/hris/__init__.py
@@ -11,7 +11,7 @@ from .company_benefit import CompanyBenefit as CompanyBenefit
 from .employment_data import EmploymentData as EmploymentData
 from .benefit_frequency import BenefitFrequency as BenefitFrequency
 from .supported_benefit import SupportedBenefit as SupportedBenefit
-from .benfit_contribution import BenfitContribution as BenfitContribution
+from .benefit_contribution import BenefitContribution as BenefitContribution
 from .individual_response import IndividualResponse as IndividualResponse
 from .payment_list_params import PaymentListParams as PaymentListParams
 from .benefit_create_params import BenefitCreateParams as BenefitCreateParams

--- a/src/finch/types/hris/benefits/individual_benefit.py
+++ b/src/finch/types/hris/benefits/individual_benefit.py
@@ -4,7 +4,7 @@ from typing import Optional
 from typing_extensions import Literal
 
 from ...._models import BaseModel
-from ..benfit_contribution import BenfitContribution
+from ..benefit_contribution import BenefitContribution
 
 __all__ = ["IndividualBenefit", "Body"]
 
@@ -21,9 +21,9 @@ class Body(BaseModel):
     for this individual.
     """
 
-    company_contribution: Optional[BenfitContribution] = None
+    company_contribution: Optional[BenefitContribution] = None
 
-    employee_deduction: Optional[BenfitContribution] = None
+    employee_deduction: Optional[BenefitContribution] = None
 
     hsa_contribution_limit: Optional[Literal["individual", "family"]] = None
     """Type for HSA contribution limit if the benefit is a HSA."""

--- a/src/finch/types/hris/benfit_contribution.py
+++ b/src/finch/types/hris/benfit_contribution.py
@@ -5,10 +5,10 @@ from typing_extensions import Literal
 
 from ..._models import BaseModel
 
-__all__ = ["BenfitContribution"]
+__all__ = ["BenefitContribution"]
 
 
-class BenfitContribution(BaseModel):
+class BenefitContribution(BaseModel):
     amount: Optional[int] = None
     """Contribution amount in cents (if `fixed`) or basis points (if `percent`)."""
 

--- a/src/finch/types/hris/company_benefit.py
+++ b/src/finch/types/hris/company_benefit.py
@@ -5,7 +5,7 @@ from typing import Optional
 from ..._models import BaseModel
 from .benefit_type import BenefitType
 from .benefit_frequency import BenefitFrequency
-from .benfit_contribution import BenfitContribution
+from .benefit_contribution import BenefitContribution
 
 __all__ = ["CompanyBenefit"]
 
@@ -13,11 +13,11 @@ __all__ = ["CompanyBenefit"]
 class CompanyBenefit(BaseModel):
     benefit_id: str
 
-    company_contribution: Optional[BenfitContribution]
+    company_contribution: Optional[BenefitContribution]
 
     description: Optional[str]
 
-    employee_deduction: Optional[BenfitContribution]
+    employee_deduction: Optional[BenefitContribution]
 
     frequency: Optional[BenefitFrequency]
 

--- a/src/finch/types/hris/employment_retrieve_many_params.py
+++ b/src/finch/types/hris/employment_retrieve_many_params.py
@@ -18,6 +18,6 @@ class Request(TypedDict, total=False):
     """A stable Finch `id` (UUID v4) for an individual in the company.
 
     There is no limit to the number of `individual_id` to send per request. It is
-    preferantial to send all ids in a single request for Finch to optimize provider
+    preferential to send all ids in a single request for Finch to optimize provider
     rate-limits.
     """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,7 +46,7 @@ class TestFinch:
         assert self.client.access_token == access_token
 
     def test_copy_default_options(self) -> None:
-        # options that have a default are overriden correctly
+        # options that have a default are overridden correctly
         copied = self.client.copy(max_retries=7)
         assert copied.max_retries == 7
         assert self.client.max_retries == 2


### PR DESCRIPTION
## What's Changing

- `the client is garbage collected is called but` -> `the client is garbage collected, but`
- more descriptive hyperlink
- `benfit` -> `benefit`