### PR TITLE
Revert "chore(docs): minor update to formatting of API link in README…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and offers both synchronous and asynchronous clients powered by [httpx](https://
 
 ## Documentation
 
-The REST API documentation can be found on [developer.tryfinch.com](https://developer.tryfinch.com/). The full API of this library can be found in [api.md](api.md).
+The REST API documentation can be found [in the Finch Documentation Center](https://developer.tryfinch.com/). The full API of this library can be found in [api.md](api.md).
 
 ## Installation
 


### PR DESCRIPTION
… (#434)"

This reverts commit b4a7b2e99450d41f8fea1113337e4dc86b64bb1b.

This preserves the custom wording this repo is using for linking to the API Documentation.