### PR TITLE
chore(codeowners): PLAT-4299 Rewrite CODEOWNERS to Match New GitHub Groups

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @Finch-API/team-platform
+*  @Finch-API/team-data-delivery


### PR DESCRIPTION
## What
Update the repository-wide CODEOWNERS assignment from `@Finch-API/team-platform` to `@Finch-API/team-data-delivery`.

## Why
The default code owner must use the new GitHub group.

## Changes
- Assign all files to `@Finch-API/team-data-delivery`.

## Notes
Configuration-only change; no application code changed.

Closes: [PLAT-4299](https://linear.app/finch/issue/PLAT-4299)
